### PR TITLE
Expand or jump in Ultisnips

### DIFF
--- a/autoload/CleverTab.vim
+++ b/autoload/CleverTab.vim
@@ -60,8 +60,8 @@ function! CleverTab#Complete(type)
 
 
   elseif a:type == 'ultisnips' && !g:CleverTab#cursor_moved && !g:CleverTab#stop
-    let g:ulti_x = UltiSnips#ExpandSnippet()
-    if g:ulti_expand_res
+    let g:ulti_x = UltiSnips#ExpandSnippetOrJump()
+    if g:ulti_expand_or_jump_res
       echom "Ultisnips"
       let g:CleverTab#next_step_direction="0"
       let g:CleverTab#stop=1


### PR DESCRIPTION
This way you can fully integrate Ultisnips with clevertab. Before that users would need another mapping for jumping for the next placeholder in Ultisnips.
The Ultinisnips call automatically does the check if it'll expand, jump or do nothing.