### PR TITLE
Added option to choose UltiSnip expand function

### DIFF
--- a/autoload/CleverTab.vim
+++ b/autoload/CleverTab.vim
@@ -81,8 +81,12 @@ function! CleverTab#Complete(type)
     return ""
 
   elseif a:type == 'ultisnips' && !g:CleverTab#cursor_moved && !g:CleverTab#stop
-    let g:ulti_x = UltiSnips#ExpandSnippetOrJump()
-    if g:ulti_expand_or_jump_res
+    if exists('g:CleverTabUltiExpandOrJump')
+      let g:ulti_x = UltiSnips#ExpandSnippetOrJump()
+    else
+      let g:ulti_x = UltiSnips#ExpandSnippet()
+    endif
+    if (exists('g:ulti_expand_or_jump_res') && g:ulti_expand_or_jump_res) || (exists('g:ulti_expand_res') && g:ulti_expand_res)
       echom "Ultisnips"
       let g:CleverTab#next_step_direction="0"
       let g:CleverTab#stop=1


### PR DESCRIPTION
By default plugin uses `UltiSnips#ExpandSnippet()`. And if `g:CleverTabUltiSnipsExpandOrJump` setted, `UltiSnips#ExpandSnippetOrJump`. This helps with autocomplete inside UltiSnips tabstops.
