### PR TITLE
Adds emmet-vim chain option

### DIFF
--- a/autoload/CleverTab.vim
+++ b/autoload/CleverTab.vim
@@ -97,6 +97,11 @@ function! CleverTab#Complete(type)
     let g:CleverTab#stop=1
     return "\<Tab>"
 
+  elseif a:type == 'emmet' && !g:CleverTab#cursor_moved && !g:CleverTab#stop
+    echom "Emmet"
+    let g:CleverTab#next_step_direction="0"
+    let g:CleverTab#stop=1
+    return emmet#expandAbbr(0, '')
 
   elseif a:type == "stop" || a:type == "next"
     if g:CleverTab#stop || g:CleverTab#eat_next==1


### PR DESCRIPTION
Hello, as you can see I've added to the chain an option to `emmet-vim`'s function `expandAbbr`.
Obviouslly, it needs `emmet-vim` plugin installed and a custom chain defined in `.vimrc` or `init.vim` to work well.

Here is the chain that I used:

```vim
inoremap <silent><tab> <c-r>=CleverTab#Complete('start')<cr>
      \<c-r>=CleverTab#Complete('tab')<cr>
      \<c-r>=CleverTab#Complete('neosnippet')<cr>
      \<c-r>=CleverTab#Complete('emmet')<cr>
      \<c-r>=CleverTab#Complete('stop')<cr>
inoremap <silent><s-tab> <c-r>=CleverTab#Complete('prev')<cr>
```